### PR TITLE
Make cvitembed compatible with the newest version of CViTjs

### DIFF
--- a/cvitembed.module
+++ b/cvitembed.module
@@ -35,13 +35,15 @@ function cvitembed_menu() {
   );
 
   foreach ($plots as $key => $details) {
-    $items['cvitjs/'.$key] = array(
-      'title' => $details['title'],
-      'page callback' => 'drupal_get_form',
-      'page arguments' => array('cvitembed_form', $key, $details['title'], $details),
-      'access arguments' => array('view cvitjs plot'),
-      'type' => MENU_NORMAL_ITEM,
-    );
+    if (!empty($details['title']) AND !empty($details['description'])) {
+      $items['cvitjs/'.$key] = array(
+        'title' => $details['title'],
+        'page callback' => 'drupal_get_form',
+        'page arguments' => array('cvitembed_form', $key, $details['title'], $details),
+        'access arguments' => array('view cvitjs plot'),
+        'type' => MENU_NORMAL_ITEM,
+      );
+    }
   }
 
   return $items;

--- a/cvitembed.module
+++ b/cvitembed.module
@@ -185,7 +185,7 @@ function cvitembed_form($form, &$form_state) {
       }
       // Otherwise, maybe this is a key/value pair?
       elseif (sizeof($pair) == 2) {
- 
+
         $pair[0] = strtolower(trim($pair[0]));
         $pair[1] = trim($pair[1]);
 
@@ -211,7 +211,7 @@ function cvitembed_form($form, &$form_state) {
       'colour' => $section_color,
       'value'  => $section_title,
     );
-  } 
+  }
 
   $form['arr_plots_legend'] = array(
     '#value' => $arr_legend,
@@ -316,7 +316,9 @@ function page_list_available_plots() {
 
   $output .= '<ul>';
   foreach ($plots as $key => $details) {
-    $output .= '<li>' . l($details['title'], 'cvitjs/'.$key) . ': ' . $details['description'] . '</li>';
+    if (!empty($details['title']) AND !empty($details['description'])) {
+      $output .= '<li>' . l($details['title'], 'cvitjs/'.$key) . ': ' . $details['description'] . '</li>';
+    }
   }
   $output .= '</ul>';
 

--- a/theme/css/style.cvitembed.css
+++ b/theme/css/style.cvitembed.css
@@ -7,6 +7,11 @@
   padding: 0;
 }
 
+#div-chart-container.cvitjs div.messages.warning {
+  margin-right: 100px;
+  margin-left: 0;
+}
+
 /* Legend */
 #cvitembed-form #legend {
   margin: 10px 15px;

--- a/theme/cvitembed_page.tpl.php
+++ b/theme/cvitembed_page.tpl.php
@@ -9,14 +9,14 @@
 ?>
 
 
-<div id="div-chart-container" width="1000" class="clearfix">
+<div id="div-chart-container" class="cvitjs" width="1000" class="clearfix">
 
   <?php
     // Render plot description.
     print drupal_render($form['description']);
   ?>
 
-  <div class="messages warning">Please be patient. These plots can be a little slow to draw.</div>
+  <div id="title-div"><div class="messages warning">Please be patient. These plots can be a little slow to draw.</div></div>
 
   <?php
     // Render CViT canvas.


### PR DESCRIPTION
This PR fixes a few known incompatibilities between this module and https://github.com/LegumeFederation/cvitjs/commit/789ce960c6d9bb4e3d22266f871d8ac1057db074. Specifically, the scoping for the Bootstrap CSS changes and a new title-div was added that contains the menu block. 

Furthermore, now that BLAST uses the same libraries version of CViTjs we were ending up with extra diagrams listed in the menu's that didn't have any use beyond showing blast hits. Thus this PR updates the code to only show entries with a title and description set.

## How to Test
- Go to any embedded CViTjs diagram and check that it renders properly. Specifically, look at the top and bottom menus
- Go to the summary page at [your site]/cvitjs and ensure blast specific entries with no description are not included. On DEV Fresh there is an extra entry for `Lens culinaris: Genome 1.2` that has nothing located on it. This should not show up in the summary list or menu.