### PR TITLE
Support Private Charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,5 @@ Provides a page per CViTjs plot in your Tripal site. This module also supports a
 ## Tips & Tricks
 - Set the title of your CViTjs pages and the labels of the links by adding a `title = Your Human Readable Title` tag in the main cvit.conf for each dataset
 - You can also add a one-line description above your diagram by adding a `description = More details about the analysis, etc.` tag in the main cvit.conf for each dataset
+- To make a chart private (i.e. controlled by the "View Private CViTjs plot" permission) add `access = private` to the main cvitjs.conf
 - This module will generate a colour-based legend for you. Simply add the following tags in the plot cvit.conf for each visualization type you want in the legend: `legend = true`, `title = My Legend label for this type`. The module will use the colo(u)r already set for the type.

--- a/cvitembed.module
+++ b/cvitembed.module
@@ -343,6 +343,7 @@ function page_list_available_plots() {
 
   if (user_access('view private cvitjs plot')) {
     $output .= '<h1 class="listing-title">Private Charts</h1>';
+    $output .= '<p>The following charts have been made available to you based on your account. Please do not share these charts with others as they are meant for internal use.</p>';
     $output .= '<ul>';
     foreach ($plots as $key => $details) {
       if (!empty($details['title']) AND !empty($details['description'])) {

--- a/cvitembed.module
+++ b/cvitembed.module
@@ -36,11 +36,17 @@ function cvitembed_menu() {
 
   foreach ($plots as $key => $details) {
     if (!empty($details['title']) AND !empty($details['description'])) {
+      if (isset($details['access']) AND ($details['access'] == 'private')) {
+        $perm = 'view private cvitjs plot';
+      }
+      else {
+        $perm = 'view cvitjs plot';
+      }
       $items['cvitjs/'.$key] = array(
         'title' => $details['title'],
         'page callback' => 'drupal_get_form',
         'page arguments' => array('cvitembed_form', $key, $details['title'], $details),
-        'access arguments' => array('view cvitjs plot'),
+        'access arguments' => array($perm),
         'type' => MENU_NORMAL_ITEM,
       );
     }
@@ -55,8 +61,11 @@ function cvitembed_menu() {
 function cvitembed_permission() {
   return array(
     'view cvitjs plot' => array(
-      'title' => t('Access CViTjs plots.'),
-    )
+      'title' => t('Access Public CViTjs plots.'),
+    ),
+    'view private cvitjs plot' => array(
+      'title' => t('Access Private CViTjs plots.'),
+    ),
   );
 }
 
@@ -291,6 +300,11 @@ function cvitembed_extract_available_plots($conf_filename, &$default_plot) {
       if (strpos($v, 'description') !== FALSE) {
         $arr_plots[$plot_code]['description'] = trim(preg_replace('/description\s=\s/', '', $v));
       }
+
+      // Access
+      if (strpos($v, 'access') !== FALSE) {
+        $arr_plots[$plot_code]['access'] = trim(preg_replace('/access\s=\s/', '', $v));
+      }
     }
   }
 
@@ -314,15 +328,33 @@ function page_list_available_plots() {
 
   $output .= '<div class="cvit-listing">';
   $output .= '<p>CViTjs provides an interactive whole genome diagram and was developed by the Legume Federation.</p>';
-  $output .= '<h1 class="listing-title">Available Charts:</h1>';
+  $output .= '<h1 class="listing-title">Public Charts:</h1>';
 
   $output .= '<ul>';
   foreach ($plots as $key => $details) {
     if (!empty($details['title']) AND !empty($details['description'])) {
-      $output .= '<li>' . l($details['title'], 'cvitjs/'.$key) . ': ' . $details['description'] . '</li>';
+      // Only show if it's not private.
+      if (!isset($details['access']) OR ($details['access'] != 'private')) {
+        $output .= '<li>' . l($details['title'], 'cvitjs/'.$key) . ': ' . $details['description'] . '</li>';
+      }
     }
   }
   $output .= '</ul>';
+
+  if (user_access('view private cvitjs plot')) {
+    $output .= '<h1 class="listing-title">Private Charts</h1>';
+    $output .= '<ul>';
+    foreach ($plots as $key => $details) {
+      if (!empty($details['title']) AND !empty($details['description'])) {
+        // Only show if it's not private.
+        if (isset($details['access']) AND ($details['access'] == 'private')) {
+          $output .= '<li>' . l($details['title'], 'cvitjs/'.$key) . ': ' . $details['description'] . '</li>';
+        }
+      }
+    }
+    $output .= '</ul>';
+
+  }
 
   $output .= '</div>';
   return $output;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- No need to include the issue number in the title :-) -->

## Metadata
<!--- If it fixes an open issue, please add the issue link below. -->
 - Issue #4

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I feel this PR is ready to be merged.
- [ ] This PR is dependent upon [PR #/ nothing]

Documentation:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

## Description
We needed to be able to support some charts remaining private while others being public.

## Testing?
- [x] I tested on a generic Tripal Site
- [ ] I tested on a KnowPulse Clone
- [ ] This PR includes automated testing

You can test this on our tripal dev site. Anonymous users should only be able to see gene and exome distribution while authenticated users should be able to see the rest of the charts. Fred is a good authenticated user to check with, simply choose fred in the user dropdown of the admin toolbar.